### PR TITLE
Intern api v2 with add device event

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,4 @@ Contributors
 * Florian Klien <florian.klien@smaxtec.com>
 * Philipp Kulich <philipp.kulich@smaxtec.com>
 * Marco Julian Moser <hyper_chrome@gmx.at>
+* Kristof Krenn <kristof.krenn@smaxtec.com>

--- a/src/sxapi/base.py
+++ b/src/sxapi/base.py
@@ -94,21 +94,6 @@ class InternAPIV2(BaseAPI):
         base_url = base_url or INTERN_API_V2
         super().__init__(base_url, api_token=api_token)
 
-    def create_device_update(self, name, update_type, update_content,
-                             information):
-        data = {
-            "name": name,
-            "update_type": update_type,
-            "update_content": update_content,
-            "information": information,
-            "create_ts": pendulum.now().isoformat()
-        }
-        return self.post("/devices/device_updates", json=data, timeout=25)
-
-    def schedule_device_update(self, device_id, device_update_id):
-        data = {"device_update_id": device_update_id}
-        return self.post(f"/devices/{device_id}/events/update_schedule", json=data, timeout=25)
-
     def create_device_event(self, device_id, event_type, event_ts, information=None):
         data = {
             "event_type": event_type,

--- a/src/sxapi/base.py
+++ b/src/sxapi/base.py
@@ -5,6 +5,7 @@ import requests
 
 PUBLIC_API_V2 = "https://api.smaxtec.com/api/v2"
 INTEGRATION_API_V2 = "https://api.smaxtec.com/integration/v2"
+INTERN_API_V2 = "https://api.smaxtec.com/internapi/v2"
 
 
 class BaseAPI(object):
@@ -84,3 +85,34 @@ class IntegrationAPIV2(BaseAPI):
         """Initialize a new integration api client instance."""
         base_url = base_url or INTEGRATION_API_V2
         super().__init__(base_url, email=email, password=password, api_token=api_token)
+
+
+class InternAPIV2(BaseAPI):
+    def __init__(self, base_url=None, api_token=None):
+        """Initialize a new low level intern API V2 client instance.
+        """
+        base_url = base_url or INTERN_API_V2
+        super().__init__(base_url, api_token=api_token)
+
+    def create_device_update(self, name, update_type, update_content,
+                             information):
+        data = {
+            "name": name,
+            "update_type": update_type,
+            "update_content": update_content,
+            "information": information,
+            "create_ts": pendulum.now().isoformat()
+        }
+        return self.post("/devices/device_updates", json=data, timeout=25)
+
+    def schedule_device_update(self, device_id, device_update_id):
+        data = {"device_update_id": device_update_id}
+        return self.post(f"/devices/{device_id}/events/update_schedule", json=data, timeout=25)
+
+    def create_device_event(self, device_id, event_type, event_ts, information=None):
+        data = {
+            "event_type": event_type,
+            "event_ts": event_ts,
+            "information": information
+        }
+        return self.post(f"/devices/{device_id}/events", json=data, timeout=25)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,8 +1,10 @@
 import mock
+from datetime import datetime
 
 from sxapi.base import (
     BaseAPI,
     IntegrationAPIV2,
+    InternAPIV2,
     PublicAPIV2,
 )
 
@@ -53,3 +55,15 @@ def test_base(mock_post, mock_get, mock_put, mock_delete):
     assert mock_get.call_count == 1
     assert mock_put.call_count == 1
     assert mock_delete.call_count == 1
+
+    internAPIv2 = InternAPIV2(api_token="test_token")
+    assert internAPIv2.api_base_url == "https://api.smaxtec.com/internapi/v2"
+    assert internAPIv2.api_token == "test_token"
+
+
+@mock.patch("requests.Session.post")
+def test_intern_v2_create_device_event(mock_post):
+    internAPIv2 = InternAPIV2(api_token="test_token")
+    ts = "2022-07-21T12:00:00"
+    internAPIv2.create_device_event(device_id="0900000001", event_type="faulty", event_ts=ts)
+    assert mock_post.call_count == 1

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,4 @@
 import mock
-from datetime import datetime
 
 from sxapi.base import (
     BaseAPI,
@@ -67,3 +66,6 @@ def test_intern_v2_create_device_event(mock_post):
     ts = "2022-07-21T12:00:00"
     internAPIv2.create_device_event(device_id="0900000001", event_type="faulty", event_ts=ts)
     assert mock_post.call_count == 1
+    assert mock_post._mock_call_args[0][0] == "https://api.smaxtec.com/internapi/v2/devices/0900000001/events"
+    assert mock_post._mock_call_args[1]["json"]["event_ts"] == "2022-07-21T12:00:00"
+    assert mock_post._mock_call_args[1]["json"]["event_type"] == "faulty"


### PR DESCRIPTION
# Summary - *The What* #
added InternAPIV2 client and create_device_event function


# Purpose - *The Why* #
Paul needs to set 80+ devices faulty and needs some automation, this will also happen in the future and with the device_event call we can set devices faulty, one needs an intern token to do it
