### PR TITLE
added observation_group endpoint

### DIFF
--- a/src/sxapi/publicV2/__init__.py
+++ b/src/sxapi/publicV2/__init__.py
@@ -3,15 +3,16 @@ from sxapi.base import (
     BaseAPI,
 )
 from sxapi.publicV2.alarms import Alarms
+from sxapi.publicV2.animalgroups import AnimalGroups
 from sxapi.publicV2.data import Data
+from sxapi.publicV2.events import Events
 from sxapi.publicV2.feedrations import Feedrations
 from sxapi.publicV2.groups import Groups
+from sxapi.publicV2.notes import Notes
+from sxapi.publicV2.observation_groups import ObservationGroups
+from sxapi.publicV2.shares import Shares
 from sxapi.publicV2.todos import Todos
 from sxapi.publicV2.users import Users
-from sxapi.publicV2.events import Events
-from sxapi.publicV2.animalgroups import AnimalGroups
-from sxapi.publicV2.notes import Notes
-from sxapi.publicV2.shares import Shares
 
 PUBLIC_API_V2_BASE_URL = "https://api.smaxtec.com/api/v2"
 
@@ -32,6 +33,7 @@ class PublicAPIV2(BaseAPI):
         self.animalgroups = AnimalGroups(api=self)
         self.notes = Notes(api=self)
         self.shares = Shares(api=self)
+        self.observation_groups = ObservationGroups(api=self)
 
         super().__init__(
             base_url,

--- a/src/sxapi/publicV2/observation_groups.py
+++ b/src/sxapi/publicV2/observation_groups.py
@@ -1,0 +1,225 @@
+class ObservationGroups:
+    """
+    This Class represents the /observation_groups endpoint of the PublicAPIV2.
+    https://api.smaxtec.com/api/v2/
+    """
+
+    def __init__(self, api=None):
+        self.api = api
+        self.path_suffix = "/observation_groups"
+
+    def post(self, name, group_type, start_date, organisation_id, **kwargs):
+        """Create a new observation group.
+
+        Args:
+            name (str): Name of the observation group.
+            group_type (str): Type of the observation group.
+            start_date (str): Start date of the observation group.
+            organisation_id (str):  ID of the organisation the observation group
+                should be created for
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Observation group on success,
+                error message else.
+
+        """
+        params = {
+            "name": name,
+            "group_type": group_type,
+            "start_date": start_date,
+            "organisation_id": organisation_id,
+        }
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        return self.api.post(self.path_suffix, json=params)
+
+    def get_dim_series_line(self, reference_type, reference_id, **kwargs):
+        """Get aggregated DIM line chart data for an organisation.
+
+        Args:
+            reference_type (str): Observation group reference type.
+            reference_id (str): ID of Observation group.
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Aggregated DIM Series on success,
+                error message else.
+
+        """
+        params = {
+            "reference_type": reference_type,
+            "reference_id": reference_id,
+        }
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + "/dim_series_line.json"
+        return self.api.get(url_suffix, json=params)
+
+    def put(self, group_id, **kwargs):
+        """Update an observation group.
+
+        Args:
+            group_id (str): ID of the observation group
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Observation group on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{group_id}"
+        return self.api.put(url_suffix, json=params)
+
+    def get(self, group_id, **kwargs):
+        """Get one observation group by ID.
+
+        Args:
+            group_id (str): ID of the observation group
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Observation group on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{group_id}"
+        return self.api.get(url_suffix, json=params)
+
+    def delete(self, group_id, **kwargs):
+        """Delete an observation group.
+
+        Args:
+            group_id (str): ID of the observation group
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Result on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{group_id}"
+        return self.api.delete(url_suffix, json=params)
+
+    def put_add_animals(self, group_id, animal_ids, **kwargs):
+        """Add animals to an observation group.
+
+        Args:
+            group_id (str): ID of the observation group
+            animal_ids (:obj:`list` of :obj:`str`): List of animal IDs
+                to add to the group
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Observation group on success,
+                error message else.
+
+        """
+        params = {"animal_ids": animal_ids}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{group_id}/add_animals"
+        return self.api.put(url_suffix, json=params)
+
+    def put_remove_animals(self, group_id, animal_ids, **kwargs):
+        """Remove animals from an observation group.
+
+        Args:
+            group_id (str): ID of the observation group
+            animal_ids (:obj:`list` of :obj:`str`): List of animal IDs
+                to remove from the group
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Observation group on success,
+                error message else.
+
+        """
+        params = {"animal_ids": animal_ids}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{group_id}/remove_animals"
+        return self.api.put(url_suffix, json=params)
+
+    def get_observ_dim_series_bar(self, observation_group_id, **kwargs):
+        """Get aggregated DIM bar char data for an observation group.
+
+        Args:
+            observation_group_id (str): ID of the observation group
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Aggregated DIM Series on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{observation_group_id}/observ_dim_series_bar.json"
+        )
+        return self.api.get(url_suffix, json=params)
+
+    def get_orga_dim_series_bar(self, organisation_id, **kwargs):
+        """Get aggregated DIM bar char data for an organisation.
+
+        Args:
+            organisation_id (str): ID of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/api/v2/
+
+        Returns:
+            dict: Response of API call. Aggregated DIM Series on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/orga_dim_series_bar.json"
+        return self.api.get(url_suffix, json=params)

--- a/tests/test_publicV2/test_observation_groups.py
+++ b/tests/test_publicV2/test_observation_groups.py
@@ -1,0 +1,165 @@
+import mock
+
+from sxapi.publicV2 import PublicAPIV2
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.post")
+def test_post(mock_post):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.post(
+        "test_name",
+        "test_group_type",
+        "test_start_date",
+        "test_organisation_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = mock_post.call_args_list[0]
+
+    assert mock_post.call_count == 1
+    assert call_args.args[0] == "/observation_groups"
+    assert call_args.kwargs["json"] == {
+        "name": "test_name",
+        "group_type": "test_group_type",
+        "start_date": "test_start_date",
+        "organisation_id": "test_organisation_id",
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.get")
+def test_get_dim_series_line(get_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.get_dim_series_line(
+        "test_reference_type",
+        "test_reference_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/observation_groups/dim_series_line.json"
+    assert call_args.kwargs["json"] == {
+        "reference_type": "test_reference_type",
+        "reference_id": "test_reference_id",
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.put")
+def test_put(put_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.put(
+        "test_group_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert call_args.args[0] == "/observation_groups/test_group_id"
+    assert call_args.kwargs["json"] == {"kwarg1": "kwarg1"}
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.get")
+def test_get(get_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.get(
+        "test_group_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/observation_groups/test_group_id"
+    assert call_args.kwargs["json"] == {"kwarg1": "kwarg1"}
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.delete")
+def test_delete(delete_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.delete(
+        "test_group_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = delete_mock.call_args_list[0]
+
+    assert delete_mock.call_count == 1
+    assert call_args.args[0] == "/observation_groups/test_group_id"
+    assert call_args.kwargs["json"] == {"kwarg1": "kwarg1"}
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.put")
+def test_put_add_animals(put_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.put_add_animals(
+        "test_group_id",
+        ["test_animal_id1", "tet_animal_id2"],
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert call_args.args[0] == "/observation_groups/test_group_id/add_animals"
+    assert call_args.kwargs["json"] == {
+        "animal_ids": ["test_animal_id1", "tet_animal_id2"],
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.put")
+def test_put_remove_animals(put_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.put_remove_animals(
+        "test_group_id",
+        ["test_animal_id1", "tet_animal_id2"],
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert call_args.args[0] == "/observation_groups/test_group_id/remove_animals"
+    assert call_args.kwargs["json"] == {
+        "animal_ids": ["test_animal_id1", "tet_animal_id2"],
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.get")
+def test_get_observ_dim_series_bar(get_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.get_observ_dim_series_bar(
+        "test_group_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/observation_groups/test_group_id/observ_dim_series_bar.json"
+    )
+    assert call_args.kwargs["json"] == {"kwarg1": "kwarg1"}
+
+
+@mock.patch("sxapi.publicV2.PublicAPIV2.get")
+def test_get_orga_dim_series_bar(get_mock):
+    test_api = PublicAPIV2()
+    test_api.observation_groups.get_orga_dim_series_bar(
+        "test_orga_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0] == "/observation_groups/test_orga_id/orga_dim_series_bar.json"
+    )
+    assert call_args.kwargs["json"] == {"kwarg1": "kwarg1"}


### PR DESCRIPTION
# Summary - *The What* #
**DO** - 
Implemented all supported calls for the  `https://api.smaxtec.com/api/v2/observation_groups` endpoint.

**DONT** - No implementation for the CLI.


# Magic - *The How* (Optional)
**DO** - Created a new Class `ObservationGroups` and added ab attribute of that class to the PulbicApiV2 class (called `observation_groups`).

Implemented it i a way that we forward all given arguments and let the API-Endpoint decide which one to use. This allows us to be compatible with updated calls in the future.


# ToDo's - *Open Point List* #
**DO**
* Documentation
