### PR TITLE
added integrationAPI  organisations endpoint

### DIFF
--- a/src/sxapi/integrationV2/__init__.py
+++ b/src/sxapi/integrationV2/__init__.py
@@ -3,6 +3,7 @@ from sxapi.base import (
     BaseAPI,
 )
 from sxapi.integrationV2.accounts import Accounts
+from sxapi.integrationV2.organisations import Organisations
 from sxapi.integrationV2.tranlations import Translations
 from sxapi.integrationV2.users import Users
 
@@ -18,6 +19,7 @@ class IntegrationAPIV2(BaseAPI):
         self.users = Users(api=self)
         self.translations = Translations(api=self)
         self.accounts = Accounts(api=self)
+        self.organisations = Organisations(api=self)
 
         super().__init__(
             base_url,

--- a/src/sxapi/integrationV2/organisations.py
+++ b/src/sxapi/integrationV2/organisations.py
@@ -1,0 +1,444 @@
+class Organisations:
+    """
+    This Class represents the /organisations endpoint for the IntegrationAPIV2
+    https://api.smaxtec.com/integration/v2/
+    """
+
+    def __init__(self, api=None):
+        self.api = api
+        self.path_suffix = "/organisations"
+
+    def post(self, name, timezone, **kwargs):
+        """Create an organisation.
+
+        Args:
+            name (str): Name of the organisation
+            timezone (str): Timezone of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. Created organisation on success,
+                error message else.
+
+        """
+        params = {"name": name, "timezone": timezone}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        return self.api.post(self.path_suffix, json=params)
+
+    def get(self, **kwargs):
+        """Get all organisation the user has access to.
+
+        Args:
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            list of dicts: Response of API call. List of
+                (organisation_Id, organisation_name, user role) on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        return self.api.get(self.path_suffix, json=params)
+
+    def get_odoo_organisations(self, **kwargs):
+        """Get all odoo organisations the user has access to.
+
+        Args:
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. List of
+                (organisation_Id, organisation_name, user role) on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + "/odoo_organisations"
+        return self.api.get(url_suffix, json=params)
+
+    def get_animal_ids(self, organisation_id, **kwargs):
+        """Get all animal official_ids of an organisation.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. List of animal ids on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/animal_ids"
+        return self.api.get(url_suffix, json=params)
+
+    def put_animals(self, organisation_id, body, **kwargs):
+        """Create/Update animals of an organisation.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            body (:obj:`list` of :obj:`dict`): List of animals to create/update
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. List of animal ids on success,
+                error message else.
+
+        """
+        params = {"body": body}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/animals"
+        return self.api.put(url_suffix, json=params)
+
+    def get_animals(self, organisation_id, **kwargs):
+        """Get all animals of an organisation.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. List of animals on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/animals"
+        return self.api.get(url_suffix, json=params)
+
+    def put_animals_by_official_id(self, organisation_id, official_id, **kwargs):
+        """Create/Update an animal of an organisation by official_id.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            official_id (str): Official ID of the animal
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Nothing on Success, error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/animals/{official_id}"
+        return self.api.put(url_suffix, json=params)
+
+    def get_animals_by_official_id(self, organisation_id, official_id, **kwargs):
+        """Get an animal of an organisation by official_id.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            official_id (str): Official ID of the animal
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. Animal on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/animals/{official_id}"
+        return self.api.get(url_suffix, json=params)
+
+    def get_animals_data_by_official_id(
+        self, organisation_id, official_id, metrics, from_date, to_date, **kwargs
+    ):
+        """Get sensordata of an animal by official_id.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            official_id (str): Official ID of the animal
+            metrics (str): Metrics of the animal
+            from_date (str): From date of the animal
+            to_date (str): To date of the animal
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. Sensor data on success,
+                error message else.
+
+        """
+        params = {
+            "metrics": metrics,
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{organisation_id}/animals/{official_id}/data.json"
+        )
+        return self.api.get(url_suffix, json=params)
+
+    def put_animals_events_by_official_id(
+        self, organisation_id, official_id, events, **kwargs
+    ):
+        """Create/Update events of an animal by official_id.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            official_id (str): Official ID of the animal
+            events (:obj:`list` of :obj:`dict`): List of events to create/update
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Nothing on Success, error message else.
+
+        """
+        params = {"events": events}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{organisation_id}/animals/{official_id}/events"
+        )
+        return self.api.put(url_suffix, json=params)
+
+    def get_animals_events_by_official_id(self, organisation_id, official_id, **kwargs):
+        """Get events of an animal by official_id.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            official_id (str): Official ID of the animal
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. List of animal events on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{organisation_id}/animals/{official_id}/events"
+        )
+        return self.api.get(url_suffix, json=params)
+
+    def get_animals_metrics_by_official_id(
+        self, organisation_id, official_id, **kwargs
+    ):
+        """Get a list of metrics available for animal.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            official_id (str): Official ID of the animal
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: List of metrics on Success, error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{organisation_id}/animals/{official_id}/metrics"
+        )
+        return self.api.get(url_suffix, json=params)
+
+    def put_animals_events(self, organisation_id, events, **kwargs):
+        """Create/Update events of an organisation.
+
+        Args:
+            organisation_id (str): Organisation ID of the organisation
+            events (:obj:`list` of :obj:`dict`): List of events to create/update
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: List of animal events on success, error message else.
+
+        """
+        params = {"events": events}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/animals_events"
+        return self.api.put(url_suffix, json=params)
+
+    def get_devices(self, organisation_id, **kwargs):
+        """Get all devices of an organisation.
+
+        Args:
+            organisation_id (str): ID of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+             dict: Response of API call. List of devices on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/devices"
+        return self.api.get(url_suffix, json=params)
+
+    def get_devices_data(
+        self, organisation_id, device_id, metrics, from_date, to_date, **kwargs
+    ):
+        """Get sensordata of a device.
+
+        Args:
+            organisation_id (str): ID of the organisation
+            device_id (str): ID of the device
+            metrics (:obj:`list` of :obj:`str`): Metrics of the device
+            from_date (str): From date of the device
+            to_date (str): To date of the device
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+            dict: Response of API call. Sensor data on success, error message else.
+
+        """
+        params = {
+            "metrics": metrics,
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{organisation_id}/devices/{device_id}/data.json"
+        )
+        return self.api.get(url_suffix, json=params)
+
+    def get_devices_readouts_latest(self, organisation_id, device_id, **kwargs):
+        """Get latest readout of a device.
+
+        Args:
+            organisation_id (str): ID of the organisation
+            device_id (str): ID of the device
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+             dict: Response of API call. Latest readout on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = (
+            self.path_suffix + f"/{organisation_id}/devices/{device_id}/readouts/latest"
+        )
+        return self.api.get(url_suffix, json=params)
+
+    def get_events(self, organisation_id, **kwargs):
+        """Get all events of an organisation.
+
+        Args:
+            organisation_id (str): ID of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+             dict: Response of API call. List of events on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/events"
+        return self.api.get(url_suffix, json=params)
+
+    def get_simple_animals(self, organisation_id, **kwargs):
+        """Get all animals of an organisation.
+
+        Args:
+            organisation_id (str): ID of the organisation
+            **kwargs: Optional parameters of the API call.
+                Find supported parameters under
+                https://api.smaxtec.com/integration/v2/
+
+        Returns:
+             dict: Response of API call. List of animals on success,
+                error message else.
+
+        """
+        params = {}
+
+        for k, v in kwargs.items():
+            params[k] = v
+
+        url_suffix = self.path_suffix + f"/{organisation_id}/simple_animals"
+        return self.api.get(url_suffix, json=params)

--- a/tests/test_integrationV2/test_intgr_organisations.py
+++ b/tests/test_integrationV2/test_intgr_organisations.py
@@ -1,0 +1,393 @@
+import mock
+
+from sxapi.integrationV2 import IntegrationAPIV2
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.post")
+def test_post(post_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.post("test_name", "test_timezone", kwarg1="kwarg1")
+
+    call_args = post_mock.call_args_list[0]
+
+    assert post_mock.call_count == 1
+    assert call_args.args[0] == "/organisations"
+    assert call_args.kwargs["json"] == {
+        "name": "test_name",
+        "timezone": "test_timezone",
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get(kwarg1="kwarg1")
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_odoo_organisations(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_odoo_organisations(kwarg1="kwarg1")
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/odoo_organisations"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_animal_ids(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_animal_ids("test_organisation_id", kwarg1="kwarg1")
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/animal_ids"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.put")
+def test_put_animals(put_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.put_animals(
+        "test_organisation_id",
+        [
+            {"animal_id": "test_animal_id", "animal_name": "test_animal_name"},
+            {"animal_id": "test_animal_id2", "animal_name": "test_animal_name2"},
+        ],
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/animals"
+    assert call_args.kwargs["json"] == {
+        "body": [
+            {"animal_id": "test_animal_id", "animal_name": "test_animal_name"},
+            {"animal_id": "test_animal_id2", "animal_name": "test_animal_name2"},
+        ],
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_animals(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_animals("test_organisation_id", kwarg1="kwarg1")
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/animals"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.put")
+def test_put_animals_by_official_id(put_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.put_animals_by_official_id(
+        "test_organisation_id",
+        "test_official_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/animals/test_official_id"
+    )
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_animals_by_official_id(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_animals_by_official_id(
+        "test_organisation_id",
+        "test_official_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/animals/test_official_id"
+    )
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_animals_data_by_official_id(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_animals_data_by_official_id(
+        "test_organisation_id",
+        "test_official_id",
+        ["metric1", "metric2"],
+        "10-10-2020",
+        "10-11-2020",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/animals/test_official_id/data.json"
+    )
+    assert call_args.kwargs["json"] == {
+        "metrics": ["metric1", "metric2"],
+        "from_date": "10-10-2020",
+        "to_date": "10-11-2020",
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.put")
+def test_put_animals_events_by_official_id(put_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.put_animals_events_by_official_id(
+        "test_organisation_id",
+        "test_official_id",
+        [
+            {
+                "event_type": "test_event_type",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value",
+            },
+            {
+                "event_type": "test_event_type2",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value2",
+            },
+        ],
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/animals/test_official_id/events"
+    )
+    assert call_args.kwargs["json"] == {
+        "events": [
+            {
+                "event_type": "test_event_type",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value",
+            },
+            {
+                "event_type": "test_event_type2",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value2",
+            },
+        ],
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_animals_events_by_official_id(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_animals_events_by_official_id(
+        "test_organisation_id",
+        "test_official_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/animals/test_official_id/events"
+    )
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_animals_metrics_by_official_id(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_animals_metrics_by_official_id(
+        "test_organisation_id",
+        "test_official_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/animals/test_official_id/metrics"
+    )
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.put")
+def test_put_animals_events(put_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.put_animals_events(
+        "test_organisation_id",
+        [
+            {
+                "event_type": "test_event_type",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value",
+            },
+            {
+                "event_type": "test_event_type2",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value2",
+            },
+        ],
+        kwarg1="kwarg1",
+    )
+
+    call_args = put_mock.call_args_list[0]
+
+    assert put_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/animals_events"
+    assert call_args.kwargs["json"] == {
+        "events": [
+            {
+                "event_type": "test_event_type",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value",
+            },
+            {
+                "event_type": "test_event_type2",
+                "event_datetime": "10-10-2020",
+                "event_value": "test_event_value2",
+            },
+        ],
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_devices(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_devices("test_organisation_id", kwarg1="kwarg1")
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/devices"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_devices_data(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_devices_data(
+        "test_organisation_id",
+        "test_device_id",
+        ["metric1", "metric2"],
+        "10-10-2020",
+        "10-11-2020",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/devices/test_device_id/data.json"
+    )
+    assert call_args.kwargs["json"] == {
+        "metrics": ["metric1", "metric2"],
+        "from_date": "10-10-2020",
+        "to_date": "10-11-2020",
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_devices_readouts_latest(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_devices_readouts_latest(
+        "test_organisation_id",
+        "test_device_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert (
+        call_args.args[0]
+        == "/organisations/test_organisation_id/devices/test_device_id/readouts/latest"
+    )
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_events(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_events(
+        "test_organisation_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/events"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }
+
+
+@mock.patch("sxapi.integrationV2.IntegrationAPIV2.get")
+def test_get_simple_animals(get_mock):
+    test_api = IntegrationAPIV2()
+    test_api.organisations.get_simple_animals(
+        "test_organisation_id",
+        kwarg1="kwarg1",
+    )
+
+    call_args = get_mock.call_args_list[0]
+
+    assert get_mock.call_count == 1
+    assert call_args.args[0] == "/organisations/test_organisation_id/simple_animals"
+    assert call_args.kwargs["json"] == {
+        "kwarg1": "kwarg1",
+    }


### PR DESCRIPTION
# Summary - *The What* #
**DO** - 
Implemented all supported calls for the  `https://api.smaxtec.com/integration/v2/organisations` endpoint.

**DONT** - No implementation for the CLI.


# Magic - *The How* (Optional)
**DO** - Created a new Class `Organisations` and added ab attribute of that class to the IntegrationAPIV2 class (called `organisations`).

Implemented it i a way that we forward all given arguments and let the API-Endpoint decide which one to use. This allows us to be compatible with updated calls in the future.


# ToDo's - *Open Point List* #
**DO**
* Documentation
