### PR TITLE
improve help messages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ description = new library to interface with the smaXtec system
 author = smaXtec
 author_email = support@smaxtec.com
 license = Apache License 2.0
-long_description = file: README.md
+long_description = file: README.rst
 long_description_content_type = text/markdown
 url = https://github.com/pyscaffold/pyscaffold/
 # Add here related links, for example:

--- a/src/sxapi/cli/cli.py
+++ b/src/sxapi/cli/cli.py
@@ -10,7 +10,6 @@ from os.path import (
 from setuptools import setup
 
 from sxapi.cli import cli_user
-from sxapi.cli.subparser.get_sensor_data import create_gsd_parser
 from sxapi.cli.subparser.token import create_token_parser
 
 
@@ -111,7 +110,8 @@ class Cli:
         main_parser = argparse.ArgumentParser(
             description=(
                 "Issue calls to the smaXtec system API to import and export data."
-            )
+            ),
+            usage="%(prog)s [options] <sub_command> [sub_command_options] [<args>]",
         )
         main_parser.add_argument(
             "--version",
@@ -127,7 +127,7 @@ class Cli:
         )
         main_parser.add_argument(
             "-t",
-            "--arg_token",
+            "--access_token",
             type=str,
             help="Access Token",
         )
@@ -146,14 +146,20 @@ class Cli:
             help="Print example config file and exits",
         )
 
-        # gsd_parser
-        subparsers = main_parser.add_subparsers(help="sub-command help")
-        create_gsd_parser(subparsers)
+        subparsers = main_parser.add_subparsers(title="sub_commands")
+        # create_gsd_parser(subparsers)
         create_token_parser(subparsers)
 
         if not args:
             main_parser.print_help()
             return
+
+        # check if subparser is called with arguments
+        # otherwise print help for subparser
+        elif args[0] in subparsers.choices.keys() and len(args) == 1:
+            subparsers.choices[args[0]].print_help()
+            return
+
         return main_parser.parse_args(args)
 
     def run(self):
@@ -171,7 +177,7 @@ class Cli:
 
         self.update_config_with_env(config_dict)
 
-        cli_user.init_user(config_dict, args.arg_token, args.use_keyring)
+        cli_user.init_user(config_dict, args.access_token, args.use_keyring)
 
         if args.status:
             self.api_status()
@@ -179,7 +185,7 @@ class Cli:
         if args.version:
             self.version_info()
 
-        if args.use_keyring and args.arg_token:
+        if args.use_keyring and args.access_token:
             print("Choose either -k (keyring), -t (argument) or no flag (environment)!")
             return
 

--- a/tests/cli_tests/test_gsd_subparser.py
+++ b/tests/cli_tests/test_gsd_subparser.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 
 from sxapi.cli.cli import Cli
 from sxapi.publicV2 import PublicAPIV2
@@ -11,6 +12,7 @@ args_parser = Cli.parse_args
 )
 @mock.patch("sxapi.cli.cli_user.check_credentials_set", return_value=True)
 @mock.patch("sxapi.cli.cli_user.public_v2_api", PublicAPIV2())
+@pytest.mark.skip()
 def test_get_sensor_data_parser(creds_mock, get_data_mock):
     namespace = args_parser(
         [


### PR DESCRIPTION
# Summary - *The What* #

- (1) Print help messages if no option or sub_command is given
- (2) Improved help messages
- (3) disabled get_sensor_data command
- (4) return `0` on error and `1` on success
- (5) In `sxapi token -n` use `builtins.input()` to ask for Username instead of sub_command argument.


# Purpose - *The Why* #
- (1) Because this is best practice
- (2) Better help messages == better UI
- (3) will be replaced with future commands
- (4) Because this is best practice
- (5) I thinks this is more intuitive

# ToDo's - *Open Point List* #
**DO**
* remove `get_sensor_data` code
* Create Enum for Return Values.


# Links #
* https://clig.dev/

![image](https://github.com/smaxtec/sxapi/assets/63156265/446879b2-4bb4-4590-8b46-5fe19b530a45)

![image](https://github.com/smaxtec/sxapi/assets/63156265/f01253e5-d95b-4fc4-bee3-fbb8edbcf159)
